### PR TITLE
Fix Jest crashes by guarding E2E window access and adding AsyncStorage/expo-av mocks

### DIFF
--- a/Menu/GameScreen.test.jsx
+++ b/Menu/GameScreen.test.jsx
@@ -49,9 +49,13 @@ jest.mock('expo-keep-awake', () => ({
   deactivateKeepAwake: jest.fn(() => Promise.resolve()),
 }));
 
-jest.mock('../assets/store/authSlice.jsx', () => ({
-  setCurrentUserPage: jest.fn(() => ({ type: 'auth/setCurrentUserPage' })),
-}));
+jest.mock('../assets/store/authSlice.jsx', () => {
+  const actual = jest.requireActual('../assets/store/authSlice.jsx');
+  return {
+    ...actual,
+    setCurrentUserPage: jest.fn(() => ({ type: 'auth/setCurrentUserPage' })),
+  };
+});
 
 jest.mock('../assets/store/sessionApiShared.jsx', () => ({
   isE2EMode: false,

--- a/assets/store/sessionApiShared.jsx
+++ b/assets/store/sessionApiShared.jsx
@@ -33,8 +33,12 @@ export const isE2EMode = (() => {
   const envFlag =
     (typeof process !== "undefined" && process?.env?.EXPO_PUBLIC_E2E === "true") ||
     (typeof process !== "undefined" && process?.env?.REACT_APP_E2E === "true");
+  const search =
+    typeof window !== "undefined" && typeof window?.location?.search === "string"
+      ? window.location.search
+      : "";
   const queryFlag =
-    typeof window !== "undefined" && new URLSearchParams(window.location.search).get("e2e") === "1";
+    typeof window !== "undefined" && new URLSearchParams(search).get("e2e") === "1";
   return Boolean(envFlag || queryFlag);
 })();
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,9 +1,26 @@
 jest.mock('react-native-reanimated', () => require('react-native-reanimated/mock'));
-jest.mock('expo-av', () => ({
-  Audio: {
-    Sound: {
-      createAsync: jest.fn().mockResolvedValue({ sound: { getStatusAsync: jest.fn(), setVolumeAsync: jest.fn(), stopAsync: jest.fn(), setPositionAsync: jest.fn(), playAsync: jest.fn(), pauseAsync: jest.fn(), unloadAsync: jest.fn() } }),
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+jest.mock(
+  'expo-av',
+  () => ({
+    Audio: {
+      Sound: {
+        createAsync: jest.fn().mockResolvedValue({
+          sound: {
+            getStatusAsync: jest.fn(),
+            setVolumeAsync: jest.fn(),
+            stopAsync: jest.fn(),
+            setPositionAsync: jest.fn(),
+            playAsync: jest.fn(),
+            pauseAsync: jest.fn(),
+            unloadAsync: jest.fn(),
+          },
+        }),
+      },
+      setAudioModeAsync: jest.fn().mockResolvedValue(undefined),
     },
-    setAudioModeAsync: jest.fn().mockResolvedValue(undefined),
-  },
-}));
+  }),
+  { virtual: true }
+);


### PR DESCRIPTION
### Motivation
- Tests were failing due to attempts to read `window.location.search` in environments without a `window`, causing `TypeError` crashes. 
- Some suites also hit native module initialization errors from `@react-native-async-storage/async-storage` and missing `expo-av` resolution during Jest runs. 
- A unit test partially mocking `authSlice` removed exported thunks needed by `sessionSlice`, causing reducer/fulfilled lookups to be undefined. 

### Description
- Guard `window.location.search` access in `assets/store/sessionApiShared.jsx` by computing a safe `search` value before passing it to `URLSearchParams`, preventing `undefined` reads. 
- Add a global AsyncStorage Jest mock in `jest.setup.js` via `require('@react-native-async-storage/async-storage/jest/async-storage-mock')` to avoid native module errors in tests that import store slices. 
- Make the `expo-av` mock in `jest.setup.js` a virtual mock (`{ virtual: true }`) so test setup does not fail when `expo-av` isn't resolvable in the test environment. 
- Update `Menu/GameScreen.test.jsx` to use `jest.requireActual('../assets/store/authSlice.jsx')` and only override `setCurrentUserPage`, preserving exported thunks (e.g. `updateUserStatus`) required by `sessionSlice`. 

### Testing
- Ran the full test suite with `npm test -- --runInBand`, which completed successfully with all test suites passing (`10/10 suites, 53/53 tests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dc9cf82f28832bbac40482cc43c55a)