### PR TITLE
Update deploy workflow to use production release triggers

### DIFF
--- a/.eas/workflows/deploy.yml
+++ b/.eas/workflows/deploy.yml
@@ -1,9 +1,10 @@
-# https://docs.expo.dev/eas/hosting/workflows/ 
+# https://docs.expo.dev/eas/hosting/workflows/
 name: Deploy
 
 on:
   push:
-    branches: ['feature/music-sound-effect']
+    branches: ['main', 'release/*']
+    tags: ['v*.*.*']
 
 jobs:
   deploy:


### PR DESCRIPTION
### Motivation
- Replace a feature-branch trigger with release-oriented triggers so production deploys only run for actual release branches or version tags.
- Ensure production-only settings remain tied to the production release triggers by keeping the job marked as production.

### Description
- Changed `on.push.branches` in ` .eas/workflows/deploy.yml` from `['feature/music-sound-effect']` to `['main', 'release/*']`.
- Added `tags: ['v*.*.*']` to trigger deployments from semantic version tags.
- Kept `environment: production` and `params.prod: true` on the `deploy` job so production behavior is unchanged.

### Testing
- Attempted to fetch the EAS workflow JSON schema with `node .agents/skills/expo-cicd-workflows/scripts/fetch.js`, which failed due to network `ENETUNREACH` to `api.expo.dev`.
- Verified the commit with `git show --stat --oneline HEAD`, which succeeded.
- Inspected the updated file with `nl -ba .eas/workflows/deploy.yml` to confirm the new triggers were written, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca3cba02c832bb0ed5d69d4bb84ca)