### PR TITLE
Clarify CI Sonar model and job naming

### DIFF
--- a/.github/workflows/ci_sonarQube_analyse.yml
+++ b/.github/workflows/ci_sonarQube_analyse.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI + Sonar (PR/Push Quality Feedback)
 
 on:
   push:
@@ -6,7 +6,9 @@ on:
      
 
 jobs:
-  analyze:
+  ci_quality_feedback:
+    # Model 1 (chosen): Sonar runs in CI for pull_request/push feedback.
+    # Keep release workflows free of duplicate Sonar runs to avoid ambiguity and duplicated cost.
     runs-on: ubuntu-latest
 
     steps:
@@ -50,8 +52,9 @@ jobs:
             test-results
           if-no-files-found: ignore
 
-      - name: SonarQube Cloud analysis
-        if: success()   # skip Sonar if any previous step failed
+      - name: SonarQube Cloud analysis (CI feedback gate)
+        # Runs only after tests/E2E pass to provide PR/push feedback signal in one place.
+        if: success()
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: "https://sonarcloud.io"
@@ -86,4 +89,3 @@ jobs:
             -Dsonar.host.url="$SONAR_HOST_URL" \
             -Dsonar.token="$SONAR_TOKEN" \
             $SONAR_OPTS
-


### PR DESCRIPTION
### Motivation
- Keep Sonar in CI (Model 1) to provide fast PR/push quality feedback and avoid duplicate Sonar runs during release pipelines.

### Description
- Update ` .github/workflows/ci_sonarQube_analyse.yml` to rename the workflow to `CI + Sonar (PR/Push Quality Feedback)`, rename the job from `analyze` to `ci_quality_feedback`, and update the Sonar step label and comments to explicitly state it is the CI feedback gate.

### Testing
- No automated tests were executed as part of this change; the modified workflow continues to run the configured automated steps (unit tests, Playwright E2E, and Sonar) when the CI pipeline runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca3db37dc832b9e2a268165ef0705)