### PR TITLE
Rename CI Sonar workflow labels to Test + E2E + Sonar

### DIFF
--- a/.github/workflows/ci_sonarQube_analyse.yml
+++ b/.github/workflows/ci_sonarQube_analyse.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test + E2E + Sonar
 
 on:
   push:
@@ -6,7 +6,8 @@ on:
      
 
 jobs:
-  analyze:
+  test-e2e-sonar:
+    name: Test + E2E + Sonar
     runs-on: ubuntu-latest
 
     steps:
@@ -86,4 +87,3 @@ jobs:
             -Dsonar.host.url="$SONAR_HOST_URL" \
             -Dsonar.token="$SONAR_TOKEN" \
             $SONAR_OPTS
-


### PR DESCRIPTION
### Motivation
- Align the workflow and job labels with the pipeline behavior (unit tests, Playwright E2E, Sonar analysis) to avoid confusion when no standalone build artifact is produced.

### Description
- Renamed the workflow `name` from `CI` to `Test + E2E + Sonar` and changed the job identifier from `analyze` to `test-e2e-sonar` while adding a job display `name` of `Test + E2E + Sonar` in `.github/workflows/ci_sonarQube_analyse.yml`.

### Testing
- Validated the updated YAML and committed the change by running `sed -n '1,80p' .github/workflows/ci_sonarQube_analyse.yml`, `git status --short`, and `nl -ba .github/workflows/ci_sonarQube_analyse.yml | sed -n '1,40p'`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca3deb720832b8158a16233eb4f6d)