### PR TITLE
Gated EAS deployment: add Release workflow and branch-protection guidance

### DIFF
--- a/.eas/workflows/deploy.yml
+++ b/.eas/workflows/deploy.yml
@@ -1,9 +1,10 @@
-# https://docs.expo.dev/eas/hosting/workflows/ 
+# EAS deploy definition.
+# Automatic deployment is triggered only by GitHub Actions `.github/workflows/release.yml`
+# after CI succeeds.
 name: Deploy
 
 on:
-  push:
-    branches: ['feature/music-sound-effect']
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/BRANCH_PROTECTION.md
+++ b/.github/BRANCH_PROTECTION.md
@@ -1,0 +1,14 @@
+# Branch protection required for deploy gating
+
+Because deployment configuration exists in `.eas/workflows/deploy.yml`, repository branch
+protection must enforce CI success before any code can reach `main`.
+
+Configure branch protection (or rulesets) for `main` with:
+
+1. **Require a pull request before merging**
+2. **Require status checks to pass before merging**
+3. Add **`CI`** as a required status check
+4. **Restrict who can push** directly to `main` (optional but recommended)
+
+With this in place, the GitHub Actions release workflow (`workflow_run` on `CI`) only sees
+successful CI runs on protected `main`, and deploy cannot proceed unless CI passed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy (gated by CI success)
+    if: >-
+      ${{
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main'
+      }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout commit from CI run
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --omit=optional
+
+      - name: Setup Expo and EAS CLI
+        uses: expo/expo-github-action@v8
+        with:
+          eas-version: latest
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Trigger EAS deploy workflow
+        run: eas workflow:run .eas/workflows/deploy.yml --non-interactive


### PR DESCRIPTION
### Motivation

- Ensure EAS hosting deploys only after CI passes on `main` by gating deployment through a GitHub Actions release workflow.
- Prevent accidental direct merges/deploys by documenting required branch protection for `main` because the deploy configuration lives in the repo.
- Replace the previous branch-specific push trigger in the EAS workflow with an explicit manual/triggered run so publishes are controlled by the release workflow.

### Description

- Changed `.eas/workflows/deploy.yml` to remove the branch `push` trigger and expose the workflow as `workflow_dispatch` with an explanatory header comment.
- Added `.github/workflows/release.yml` which listens for `workflow_run` events from the `CI` workflow and, when the run completed successfully for a `push` to `main`, checks out the CI commit, installs deps, sets up Expo/EAS, and invokes `eas workflow:run .eas/workflows/deploy.yml --non-interactive`.
- Added `.github/BRANCH_PROTECTION.md` documenting required branch protection rules for `main` to ensure CI is enforced before merges and to make the deploy gating effective.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca3d6fcf8832b972eb224d1e2b3b3)