### PR TITLE
ci: harden EAS deploy workflow execution

### DIFF
--- a/.eas/workflows/deploy.yml
+++ b/.eas/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches: ['main', 'release/*']
     tags: ['v*.*.*']
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   deploy:


### PR DESCRIPTION
### Motivation
- Prevent overlapping deploy runs and allow manual deployments by adding a manual trigger and concurrency controls to the EAS hosting workflow.

### Description
- Add `workflow_dispatch` trigger and a `concurrency` block (`group: deploy-${{ github.ref }}`, `cancel-in-progress: true`) to `.eas/workflows/deploy.yml` while leaving the existing push/tag triggers and the `deploy` job (`type: deploy`, `environment: production`, `params: prod: true`) unchanged.

### Testing
- Validated YAML parsing with `ruby -e "require 'yaml'; YAML.load_file('.eas/workflows/deploy.yml'); puts 'YAML OK'"`, which succeeded.
- Attempted schema validation with `node .agents/skills/expo-cicd-workflows/scripts/validate.js .eas/workflows/deploy.yml`, but it failed due to network `ENETUNREACH` errors when contacting `api.expo.dev` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca9eda34c832b9564b891ff061252)