### PR TITLE
[Follow-up] Fix EAS deploy workflow schema validation for dispatch and concurrency

### DIFF
--- a/.eas/workflows/deploy.yml
+++ b/.eas/workflows/deploy.yml
@@ -5,11 +5,11 @@ on:
   push:
     branches: ['main', 'release/*']
     tags: ['v*.*.*']
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 concurrency:
-  group: deploy-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ workflow.filename }}-${{ github.ref }}
+  cancel_in_progress: true
 
 jobs:
   deploy:


### PR DESCRIPTION
### Motivation
- Prevent EAS workflow schema validation failures by ensuring the manual trigger is an object and the concurrency block matches the EAS schema.
- Preserve the original deploy behavior while enabling safe manual deployments and concurrency protection.

### Description
- Updated `.eas/workflows/deploy.yml` to set `workflow_dispatch: {}` so `on.workflow_dispatch` is an object per the EAS schema.
- Reworked the `concurrency` block to use the EAS-required values `group: ${{ workflow.filename }}-${{ github.ref }}` and `cancel_in_progress: true` instead of a custom group and `cancel-in-progress`.
- No other job behavior or parameters were changed; the `deploy` job remains `type: deploy`, `environment: production`, `params: prod: true`.

### Testing
- Ran a YAML parse check with `ruby -e "require 'yaml'; YAML.load_file('.eas/workflows/deploy.yml'); puts 'YAML OK'"`, which succeeded.
- Ran the local validator `node .agents/skills/expo-cicd-workflows/scripts/validate.js .eas/workflows/deploy.yml`, which failed due to a missing `ajv` package error in the environment.
- Attempted `npm install --prefix .agents/skills/expo-cicd-workflows/scripts` to install validator deps, which failed with `403 Forbidden` from the npm registry, preventing schema validation in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcace0b774832bac380e0705887455)