### PR TITLE
Fix null workflow trigger objects in CI/EAS YAMLs

### DIFF
--- a/.eas/workflows/deploy.yml
+++ b/.eas/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches: ['main', 'release/*']
     tags: ['v*.*.*']
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 concurrency:
   group: deploy-${{ github.ref }}

--- a/.github/workflows/ci_sonarQube_analyse.yml
+++ b/.github/workflows/ci_sonarQube_analyse.yml
@@ -2,7 +2,7 @@ name: Test + E2E + Sonar
 
 on:
   push:
-  pull_request:
+  pull_request: {}
      
 
 jobs:


### PR DESCRIPTION
### Motivation
- Prevent workflow validation errors caused by bare trigger keys parsing as `null` by ensuring trigger entries are explicit objects for GitHub Actions and EAS.

### Description
- Set `workflow_dispatch` to an explicit empty object in `.eas/workflows/deploy.yml` (`workflow_dispatch: {}`) and set `pull_request` to an explicit empty object in `.github/workflows/ci_sonarQube_analyse.yml` (`pull_request: {}`).

### Testing
- Parsed the updated YAML files with Ruby `YAML.safe_load` which succeeded and reported `YAML parse OK`.
- Attempted to parse with a Python `yaml` invocation but it failed due to a missing `PyYAML` package in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dcb00714c4832bb5eb68b2a041a236)