### PR TITLE
Add web E2E guardrail & recoverability tests and stable testIDs

### DIFF
--- a/LobbyMatchMaking/MultiplayerMenu.jsx
+++ b/LobbyMatchMaking/MultiplayerMenu.jsx
@@ -158,6 +158,7 @@ const MatchListPage = ({ navigation }) => {
       {/* Header */}
       <View style={styles.header}>
         <Pressable
+          testID="match-list-back-button"
           style={styles.backButton}
           onPress={() => navigation.goBack()}
         >

--- a/Menu/Home.jsx
+++ b/Menu/Home.jsx
@@ -169,6 +169,7 @@ const HomePage = ({
               </Pressable>
             </View>
             <Pressable
+              testID="offline-choice-cancel-button"
               style={[styles.button, styles.cancelButton]}
               onPress={onCancelOfflineChoice}
             >

--- a/e2e/web.e2e.spec.js
+++ b/e2e/web.e2e.spec.js
@@ -4,11 +4,25 @@ const openAppInE2EMode = async (page) => {
   await page.goto("/?e2e=1");
 };
 
-const guestLogin = async (page) => {
+const openGuestNameModal = async (page) => {
   await page.getByTestId("login-guest-button").click();
-  await page.getByTestId("guest-name-input").fill("E2E Guest");
+  await expect(page.getByTestId("guest-name-modal")).toBeVisible();
+};
+
+const submitGuestName = async (page, name) => {
+  await page.getByTestId("guest-name-input").fill(name ?? "E2E Guest");
   await page.getByTestId("guest-name-confirm-button").click();
+};
+
+const guestLogin = async (page, name = "E2E Guest") => {
+  await openGuestNameModal(page);
+  await submitGuestName(page, name);
   await expect(page.getByTestId("home-screen")).toBeVisible();
+};
+
+const openMultiplayerFromHome = async (page) => {
+  await page.getByTestId("home-play-multiplayer-button").click();
+  await expect(page.getByTestId("match-list-screen")).toBeVisible();
 };
 
 test("guest login routes to home", async ({ page }) => {
@@ -16,15 +30,35 @@ test("guest login routes to home", async ({ page }) => {
   await guestLogin(page);
 });
 
+test("guest login rejects invalid guest name and stays on login", async ({ page }) => {
+  await openAppInE2EMode(page);
+  await openGuestNameModal(page);
+  await submitGuestName(page, "   ");
+
+  await expect(page.getByTestId("guest-name-modal")).toBeVisible();
+  await expect(page.getByTestId("login-guest-button")).toBeVisible();
+  await expect(page.getByTestId("home-screen")).not.toBeVisible();
+});
+
 test("multiplayer lobby flow can create a match", async ({ page }) => {
   await openAppInE2EMode(page);
   await guestLogin(page);
 
-  await page.getByTestId("home-play-multiplayer-button").click();
-  await expect(page.getByTestId("match-list-screen")).toBeVisible();
+  await openMultiplayerFromHome(page);
 
   await page.getByTestId("match-list-create-button").click();
   await expect(page.getByTestId("waiting-room-screen")).toBeVisible();
+});
+
+test("multiplayer flow is resilient across back navigation and re-entry", async ({ page }) => {
+  await openAppInE2EMode(page);
+  await guestLogin(page);
+
+  await openMultiplayerFromHome(page);
+  await page.getByTestId("match-list-back-button").click();
+  await expect(page.getByTestId("home-screen")).toBeVisible();
+
+  await openMultiplayerFromHome(page);
 });
 
 test("local game flow can perform turn action", async ({ page }) => {
@@ -38,4 +72,17 @@ test("local game flow can perform turn action", async ({ page }) => {
 
   await page.getByTestId("game-skip-turn-button").click();
   await expect(page.getByTestId("game-exit-button")).toBeVisible();
+});
+
+test("offline mode modal cancellation keeps user on home and out of game", async ({ page }) => {
+  await openAppInE2EMode(page);
+  await guestLogin(page);
+
+  await page.getByTestId("home-play-offline-button").click();
+  await expect(page.getByTestId("offline-choice-modal")).toBeVisible();
+  await page.getByTestId("offline-choice-cancel-button").click();
+
+  await expect(page.getByTestId("offline-choice-modal")).not.toBeVisible();
+  await expect(page.getByTestId("home-screen")).toBeVisible();
+  await expect(page.getByTestId("game-screen")).not.toBeVisible();
 });


### PR DESCRIPTION
### Motivation
- Improve end-to-end coverage for login guardrails and navigation recoverability to prevent regressions in critical flows. 
- Ensure E2E selectors are stable and testID-based so Playwright selectors remain reliable. 

### Description
- Refactored `e2e/web.e2e.spec.js` to add reusable helpers: `openAppInE2EMode`, `openGuestNameModal`, `submitGuestName`, `guestLogin`, and `openMultiplayerFromHome` for clearer setup and reuse. 
- Added a test that submits an invalid guest name (whitespace) and asserts the guest-name modal/login remains visible and `home-screen` does not appear. 
- Added a test that opens the offline-choice modal then cancels it via a stable `testID` and asserts `game-screen` is not visible and user stays on `home-screen`. 
- Added a multiplayer resilience test that opens the match list, navigates back using a stable `testID`, and re-enters to confirm the `match-list-screen` loads. 
- Introduced stable testIDs used by these tests: `offline-choice-cancel-button` in `Menu/Home.jsx` and `match-list-back-button` in `LobbyMatchMaking/MultiplayerMenu.jsx`. 

### Testing
- Ran the web E2E suite with `npm run e2e:web -- e2e/web.e2e.spec.js`, which failed to start browser instances because Playwright browsers are not installed in this environment (error: missing Chromium executable). 
- No other automated test failures in code-level assertions were observed in this run because Playwright could not launch browsers; install browsers with `npx playwright install` to execute the new E2E scenarios.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd47855c94832b939d9b3ed2636120)