### PR TITLE
Fix GameScreen exit flow to pop/reset instead of navigate

### DIFF
--- a/Menu/GameScreen.jsx
+++ b/Menu/GameScreen.jsx
@@ -14,6 +14,7 @@ import { useWebSocket } from '../assets/shared/webSocketConnection.jsx'; // Impo
 import { setCurrentUserPage } from '../assets/store/authSlice.jsx';
 import { leaveMatch } from '../assets/store/sessionSlice.jsx';
 import { activateKeepAwakeAsync, deactivateKeepAwake } from 'expo-keep-awake';
+import { CommonActions } from '@react-navigation/native';
 import { createGameScreenStyles } from './GameScreen.styles.js';
 import Instructions from './Instructions.jsx';
 import { emitMultiplayerBotTurn, getBotDifficultyForTurn, isBotControlledPlayer, runBotTurn } from './botLogic.js';
@@ -315,12 +316,21 @@ export default function GameScreen({ route, navigation }) {
 
   const confirmExitGame = () => {
     setShowExitModal(false); // Close the modal
-    if (mode === 'local') {
-      navigation.navigate('Login');
-    } else {
-      navigation.navigate('Home');
-      handleLeaveMatch(); // Call the function to leave the match
+    if (mode === 'multiplayer') {
+      handleLeaveMatch();
     }
+
+    if (navigation.canGoBack()) {
+      navigation.goBack();
+      return;
+    }
+
+    navigation.dispatch(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: mode === 'local' ? 'Login' : 'Home' }],
+      })
+    );
   };
 
   const handleLeaveMatch = () => {

--- a/Menu/GameScreen.test.jsx
+++ b/Menu/GameScreen.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { act, render } from '@testing-library/react-native';
+import { act, fireEvent, render } from '@testing-library/react-native';
 import { useDispatch, useSelector } from 'react-redux';
 import * as RN from 'react-native';
 
@@ -397,5 +397,68 @@ describe('GameScreen', () => {
 
     expect(emitMultiplayerBotTurn).not.toHaveBeenCalled();
     expect(runBotTurn).not.toHaveBeenCalled();
+  });
+
+  test('exit confirmation uses goBack when the game screen can go back', async () => {
+    configureSelectors(createState());
+    const navigation = {
+      canGoBack: jest.fn(() => true),
+      goBack: jest.fn(),
+      dispatch: jest.fn(),
+      navigate: jest.fn(),
+    };
+
+    const { getAllByText, getByTestId } = render(
+      <GameScreen route={{ params: { mode: 'bot', matchId: 1 } }} navigation={navigation} />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.press(getByTestId('game-exit-button'));
+    const exitButtons = getAllByText('Exit');
+    fireEvent.press(exitButtons[exitButtons.length - 1]);
+
+    expect(navigation.goBack).toHaveBeenCalledTimes(1);
+    expect(navigation.dispatch).not.toHaveBeenCalled();
+    expect(navigation.navigate).not.toHaveBeenCalled();
+  });
+
+  test('exit confirmation resets to home when no back route exists', async () => {
+    configureSelectors(createState());
+    dispatchMock.mockReturnValue({
+      unwrap: () => Promise.resolve(),
+    });
+    const navigation = {
+      canGoBack: jest.fn(() => false),
+      goBack: jest.fn(),
+      dispatch: jest.fn(),
+      navigate: jest.fn(),
+    };
+
+    const { getAllByText, getByTestId } = render(
+      <GameScreen route={{ params: { mode: 'multiplayer', matchId: 1 } }} navigation={navigation} />
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    fireEvent.press(getByTestId('game-exit-button'));
+    const exitButtons = getAllByText('Exit');
+    fireEvent.press(exitButtons[exitButtons.length - 1]);
+
+    expect(navigation.goBack).not.toHaveBeenCalled();
+    expect(navigation.dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'RESET',
+        payload: {
+          index: 0,
+          routes: [{ name: 'Home' }],
+        },
+      })
+    );
+    expect(navigation.navigate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent the `Game` route from remaining mounted behind destination screens by avoiding `navigation.navigate('Home')` and using stack-removing actions instead. 
- Ensure consistent exit behavior across local, bot, and multiplayer flows so repeated enter/exit cycles do not accumulate hidden `GameScreen` instances. 

### Description
- Updated `confirmExitGame` in `Menu/GameScreen.jsx` to call `handleLeaveMatch()` for multiplayer and then use `navigation.goBack()` when `navigation.canGoBack()` is true. 
- When no back route exists, the exit now falls back to `navigation.dispatch(CommonActions.reset(...))` to reset to `Home` (or `Login` for local mode) instead of `navigation.navigate(...)`. 
- Imported `CommonActions` from `@react-navigation/native`. 
- Added regression tests in `Menu/GameScreen.test.jsx` that simulate the exit flow to verify the `goBack` path and the `RESET` fallback path, and adjusted test mocks to support the new flow (including mocking `dispatch` return shape for `leaveMatch`).

### Testing
- Ran the screen tests with `npx jest Menu/GameScreen.test.jsx --runInBand`. 
- All tests in that file passed (`8 passed, 0 failed`). 
- The new tests cover the `goBack` path when a back route exists and the `CommonActions.reset` path when none exists.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb1d98e48832b923d041cafb618d2)