### PR TITLE
Make Game screen lifecycle focus-aware

### DIFF
--- a/AppNavigator.jsx
+++ b/AppNavigator.jsx
@@ -69,8 +69,8 @@ export default function AppNavigator() {
       <Stack.Navigator screenOptions={{ headerShown: false }}>
         {isLoggedIn ? (
           <>
-            <Stack.Screen name="Home" component={HomeScreen} options={{ unmountOnBlur: true }}/>
-            <Stack.Screen name="Game" component={GameScreen} options={{ unmountOnBlur: true }}/>
+            <Stack.Screen name="Home" component={HomeScreen}/>
+            <Stack.Screen name="Game" component={GameScreen}/>
             <Stack.Screen name="MatchList" component={MatchListPage} />
             <Stack.Screen name="WaitingRoom" component={WaitingRoom} />
           </>
@@ -78,13 +78,13 @@ export default function AppNavigator() {
           <>
             <Stack.Screen name="Login" component={LoginPage} />
             <Stack.Screen name="Register" component={RegisterPage} />
-            <Stack.Screen name="Home" component={HomeScreen}  options={{ unmountOnBlur: true }}/>
-            <Stack.Screen name="Game" component={GameScreen} options={{ unmountOnBlur: true }} />
+            <Stack.Screen name="Home" component={HomeScreen} />
+            <Stack.Screen name="Game" component={GameScreen} />
           </>
         ) : (
           <>
             <Stack.Screen name="Login" component={LoginPage} />
-            <Stack.Screen name="Register" component={RegisterPage} options={{ unmountOnBlur: true }} />
+            <Stack.Screen name="Register" component={RegisterPage} />
           </>
         )}
       </Stack.Navigator>

--- a/Menu/GameScreen.jsx
+++ b/Menu/GameScreen.jsx
@@ -18,6 +18,7 @@ import { createGameScreenStyles } from './GameScreen.styles.js';
 import Instructions from './Instructions.jsx';
 import { emitMultiplayerBotTurn, getBotDifficultyForTurn, isBotControlledPlayer, runBotTurn } from './botLogic.js';
 import { playSound, stopSound } from '../assets/shared/audioManager';
+import { useFocusEffect } from '@react-navigation/native';
 
 const buildPlayerColorsFromPlayers = (players = []) => {
   if (!Array.isArray(players) || players.length < 2) return null;
@@ -88,37 +89,47 @@ export default function GameScreen({ route, navigation }) {
     [currentMatch, user]
   );
 
-  useEffect(() => {
-    let mounted = true;
+  useFocusEffect(
+    React.useCallback(() => {
+      let isScreenFocused = true;
 
-    setCurrentUserPage('Game');
-    dispatch(resetGameState());
-    dispatch(resetAnimationState());
+      dispatch(setCurrentUserPage('Game'));
+      dispatch(resetGameState());
+      dispatch(resetAnimationState());
 
-    if (isOnline == false) {
-      dispatch(setActivePlayer("blue"));
-      dispatch(setCurrentPlayerColor("blue"));
-    }
-    // Keep the device awake when the user is on the GameScreen
-    activateKeepAwakeAsync()
-      .then(() => {
-        if (mounted) {
-          keepAwakeActivatedRef.current = true;
-        }
-      })
-      .catch((error) => {
-        console.error('Failed to activate keep-awake on game screen:', error);
-      });
+      if (isOnline === false) {
+        dispatch(setActivePlayer('blue'));
+        dispatch(setCurrentPlayerColor('blue'));
+      }
 
-    return () => {
-      mounted = false;
-      // Deactivate keep awake when leaving the GameScreen
-      if (!keepAwakeActivatedRef.current) return;
-      deactivateKeepAwake().catch((error) => {
-        console.warn('Failed to deactivate keep-awake on game screen:', error);
-      });
-    };
-  }, []);
+      // Keep the device awake while the GameScreen is focused.
+      activateKeepAwakeAsync()
+        .then(() => {
+          if (isScreenFocused) {
+            keepAwakeActivatedRef.current = true;
+          }
+        })
+        .catch((error) => {
+          console.error('Failed to activate keep-awake on game screen:', error);
+        });
+
+      return () => {
+        isScreenFocused = false;
+        setShowExitModal(false);
+
+        // Deactivate keep-awake when leaving the GameScreen.
+        if (!keepAwakeActivatedRef.current) return;
+
+        deactivateKeepAwake()
+          .catch((error) => {
+            console.warn('Failed to deactivate keep-awake on game screen:', error);
+          })
+          .finally(() => {
+            keepAwakeActivatedRef.current = false;
+          });
+      };
+    }, [dispatch, isOnline])
+  );
 
   useEffect(() => {
     setGameIsStarted(true);

--- a/Menu/GameScreen.test.jsx
+++ b/Menu/GameScreen.test.jsx
@@ -44,6 +44,14 @@ jest.mock('@expo/vector-icons', () => ({
   MaterialIcons: 'MaterialIcons',
 }));
 
+jest.mock('@react-navigation/native', () => {
+  const actual = jest.requireActual('@react-navigation/native');
+  return {
+    ...actual,
+    useFocusEffect: jest.fn((effect) => effect()),
+  };
+});
+
 jest.mock('expo-keep-awake', () => ({
   activateKeepAwakeAsync: jest.fn(() => Promise.resolve()),
   deactivateKeepAwake: jest.fn(() => Promise.resolve()),


### PR DESCRIPTION
### Motivation
- Prevent screens from unmounting on blur to preserve in-memory state during navigation transitions.  
- Ensure side effects that assume a visible screen (keep-awake, game reset, subscriptions) run only while the screen is focused.  
- Make lifecycle behavior testable without wrapping components in a `NavigationContainer` by relying on navigation focus hooks instead of mount-only effects.

### Description
- Removed `unmountOnBlur` options from stack routes in `AppNavigator.jsx` so `Home`, `Game`, `Register` and related entries remain mounted across navigation transitions.  
- Replaced the mount-based GameScreen lifecycle block with a navigation-aware effect using `useFocusEffect` in `Menu/GameScreen.jsx`, moving screen-entry logic (dispatching `setCurrentUserPage`, `resetGameState`, `resetAnimationState`, and initial color setup) into focus and cleaning on blur.  
- Moved keep-awake activation into the focus handler and deactivation into the focus cleanup, guarding with a `keepAwakeActivatedRef` to avoid leaking the keep-awake state.  
- Updated `Menu/GameScreen.test.jsx` to mock `useFocusEffect` so the focus lifecycle runs in tests without requiring a `NavigationContainer`.

### Testing
- Ran the full test suite with `npm test -- --runInBand --watchAll=false`, which revealed the focus lifecycle required a test mock and produced one failing suite before the test update.  
- After adding a `useFocusEffect` mock, ran `npm test -- Menu/GameScreen.test.jsx --runInBand --watchAll=false`, and the GameScreen tests passed (`6 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb1db2800832b9214fc4810b4621d)