### PR TITLE
Reduce bot turn delay from 1000ms to 500ms for improved responsiveness

### DIFF
--- a/GameComponents/Bases.jsx
+++ b/GameComponents/Bases.jsx
@@ -156,6 +156,30 @@ export default function Bases() {
         });
     }, [dispatch]);
 
+    const getActiveTurnOutlineColor = useCallback((color) => {
+        if (!color) {
+            return theme.colors.shadowColor;
+        }
+
+        return theme.colors[color] || theme.colors.shadowColor;
+    }, [theme.colors]);
+
+    const getActiveTurnOutlineStyle = useCallback((color) => {
+        if (activePlayer !== color) {
+            return null;
+        }
+
+        const outlineColor = getActiveTurnOutlineColor(color);
+        return {
+            borderColor: outlineColor,
+            shadowColor: outlineColor,
+            shadowOffset: { width: 0, height: 0 },
+            shadowOpacity: 0.85,
+            shadowRadius: isSmallScreen ? 22 : 34,
+            elevation: isSmallScreen ? 5 : 7,
+        };
+    }, [activePlayer, getActiveTurnOutlineColor, isSmallScreen]);
+
     // ─── Styles ───────────────────────────────────────────────────────────
     const styles = StyleSheet.create({
         circleContainer: {
@@ -219,14 +243,14 @@ export default function Bases() {
         top: { top: isSmallScreen ? 3 : 20, right: isSmallScreen ? 3 : 20, transform: [{ rotate: '180deg' }] },
         bottom: { bottom: isSmallScreen ? 3 : 20, left: isSmallScreen ? 3 : 20 },
         right: { bottom: isSmallScreen ? 3 : 20, right: isSmallScreen ? 3 : 20, transform: [{ rotate: '180deg' }] },
-        red: { backgroundColor: theme.colors.red, borderColor: theme.colors.border, shadowColor: activePlayer === "red" ? theme.colors.shadowColor : "", shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0.7, shadowRadius: 50 },
-        yellow: { backgroundColor: theme.colors.yellow, borderColor: theme.colors.border, shadowColor: activePlayer === "yellow" ? theme.colors.shadowColor : "", shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0.7, shadowRadius: 50 },
-        blue: { backgroundColor: theme.colors.blue, borderColor: theme.colors.border, shadowColor: activePlayer === "blue" ? theme.colors.shadowColor : "", shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0.7, shadowRadius: 50 },
-        green: { backgroundColor: theme.colors.green, borderColor: theme.colors.border, shadowColor: activePlayer === "green" ? theme.colors.shadowColor : "", shadowOffset: { width: 0, height: 0 }, shadowOpacity: 0.7, shadowRadius: 50 },
-        blue2: { shadowColor: activePlayer === "blue" ? theme.colors.shadowColor : "", shadowOffset: { width: 0, height: 0 }, shadowOpacity: activePlayer === "blue" ? 0.7 : "", shadowRadius: activePlayer === "blue" ? 50 : "" },
-        red0: { shadowColor: activePlayer === "red" ? theme.colors.shadowColor : "", shadowOffset: { width: 0, height: 0 }, shadowOpacity: activePlayer === "red" ? 0.7 : "", shadowRadius: activePlayer === "red" ? 50 : "" },
-        yellow1: { shadowColor: activePlayer === "yellow" ? theme.colors.shadowColor : "", shadowOffset: { width: 0, height: 0 }, shadowOpacity: activePlayer === "yellow" ? 0.7 : "", shadowRadius: activePlayer === "yellow" ? 50 : "" },
-        green3: { shadowColor: activePlayer === "green" ? theme.colors.shadowColor : "", shadowOffset: { width: 0, height: 0 }, shadowOpacity: activePlayer === "green" ? 0.7 : "", shadowRadius: activePlayer === "green" ? 50 : "" },
+        red: { backgroundColor: theme.colors.red, borderColor: theme.colors.border },
+        yellow: { backgroundColor: theme.colors.yellow, borderColor: theme.colors.border },
+        blue: { backgroundColor: theme.colors.blue, borderColor: theme.colors.border },
+        green: { backgroundColor: theme.colors.green, borderColor: theme.colors.border },
+        blue2: {},
+        red0: {},
+        yellow1: {},
+        green3: {},
     });
 
     const activePlayerRef = useRef(activePlayer);
@@ -572,6 +596,8 @@ export default function Bases() {
         { marginVertical: 5 },
         cardUsed && { backgroundColor: '#ddd', opacity: 0.7 },
         styles[color + i],
+        getActiveTurnOutlineStyle(color),
+        activePlayer === color && { borderWidth: isSmallScreen ? 1.5 : 2.5 },
         color === "green" && { transform: [{ rotate: '180deg' }] },
     ]);
 
@@ -629,7 +655,7 @@ export default function Bases() {
                             ))}
                         </View>
                     </View>
-                    <View style={[styles.corner, styles[color]]}>
+                    <View style={[styles.corner, styles[color], getActiveTurnOutlineStyle(color), activePlayer === color && { borderWidth: isSmallScreen ? 1 : 3 }]}>
                         {Array.from({ length: 4 }).map((_, j) => (
                             <View key={`${color}-${j + 1}`} style={styles.circle}>
                                 {renderInCirclePlayers(j, playerType, i)}
@@ -640,7 +666,12 @@ export default function Bases() {
                         testID={`enter-soldier-${color}`}
                         ref={color === 'blue' ? blueEnterSoldierRef : undefined}
                         onLayout={color === 'blue' ? reportBlueEnterSoldierAnchor : undefined}
-                        style={[styles.button, styles[color + i], { marginVertical: 5 }]}
+                        style={[
+                            styles.button,
+                            { marginVertical: 5 },
+                            getActiveTurnOutlineStyle(color),
+                            activePlayer === color && { borderWidth: isSmallScreen ? 1.5 : 2.5 },
+                        ]}
                         onPress={() => enterNewSoldierHandler(color)}
                     >
                         {

--- a/Menu/botLogic.js
+++ b/Menu/botLogic.js
@@ -114,7 +114,7 @@ export const emitMultiplayerBotTurn = ({
   sendMessage,
   sendMatchCommand,
   shouldCancel = () => false,
-  delayMs = 1000,
+  delayMs = 500,
   randomFn,
   disableNoise = false,
 }) => {


### PR DESCRIPTION
This pull request refactors how active player highlighting is handled for base components, making the outline and shadow effects more consistent and easier to maintain. It also slightly reduces the bot turn delay for a snappier user experience.

**UI Refactor and Highlighting Improvements:**

* Refactored base highlighting logic by removing inline conditional styles from the `StyleSheet` and centralizing active player outline and shadow styling in new helper functions (`getActiveTurnOutlineColor` and `getActiveTurnOutlineStyle`) in `Bases.jsx`. This makes the code more maintainable and the highlight effect more consistent. [[1]](diffhunk://#diff-2d7719a6519db3c65bcc5813dce2d9f315d2158455ff6c9f6d023ea50cee9cdfR159-R182) [[2]](diffhunk://#diff-2d7719a6519db3c65bcc5813dce2d9f315d2158455ff6c9f6d023ea50cee9cdfL222-R253)
* Updated all relevant style applications in `Bases.jsx` to use the new outline style helpers, ensuring that border width and highlight effects are only applied to the active player’s base and buttons. [[1]](diffhunk://#diff-2d7719a6519db3c65bcc5813dce2d9f315d2158455ff6c9f6d023ea50cee9cdfR599-R600) [[2]](diffhunk://#diff-2d7719a6519db3c65bcc5813dce2d9f315d2158455ff6c9f6d023ea50cee9cdfL632-R658) [[3]](diffhunk://#diff-2d7719a6519db3c65bcc5813dce2d9f315d2158455ff6c9f6d023ea50cee9cdfL643-R674)

**Gameplay Experience:**

* Reduced the default bot turn delay from 1000ms to 500ms in `botLogic.js`, making bot responses feel faster and more responsive.